### PR TITLE
README: use backticks for header names and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ A very simple WebExtension to prevent Imgur from preventing you from viewing ima
 
 Currently, when you visit an image URL directly, the image is still displayed inside an HTML document. This viewing mode even requires JavaScript to function! This is not ideal.
 
-Setting the "Accept" header to "*/*" causes Imgur to serve the raw image file, restoring the UX to some semblance of sanity.
+Setting the `Accept` header to `*/*` causes Imgur to serve the raw image file, restoring the UX to some semblance of sanity.


### PR DESCRIPTION
This was needed to make `*/*` render correctly. For consistency, I changed `Accept` too.